### PR TITLE
Support building RC releases

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,24 +17,3 @@ jobs:
         run: python -m pip install --upgrade pip wheel
       - name: Build wheel
         run: python setup.py bdist_wheel
-  check-version-conflict:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7]
-    steps:
-      - uses: actions/checkout@v1
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Upgrade pip & wheel
-        run: python -m pip install --upgrade pip wheel
-      - name: Check if version needs to be bumped
-        uses: inmar/actions-dpn-python-version-check@v1.0.3
-        with:
-          pypi_hostname: ${{ secrets.DPN_PYPI_HOSTNAME }}
-          pypi_username: ${{ secrets.DPN_PYPI_USERNAME }}
-          pypi_password: ${{ secrets.DPN_PYPI_PASSWORD }}
-          package_name: inmar-redis-py-cluster
-          use_package_version: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip & wheel
         run: python -m pip install --upgrade pip wheel
+      - name: Set wheel version
+        run: echo ::set-env name=INMAR_REDIS_PY_CLUSTER_VERSION::${GITHUB_REF#refs/*/}
       - name: Build wheel
         run: python setup.py bdist_wheel
       - name: Publish wheels

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(os.path.join('docs', 'release-notes.rst')) as f:
 
 setup(
     name="inmar-redis-py-cluster",
-    version="2.0.0",
+    version=os.environ.get("INMAR_REDIS_PY_CLUSTER_VERSION"),
     description="Library for communicating with Redis Clusters. Built on top of redis-py lib",
     long_description=readme + '\n\n' + history,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Package version is now based off of the github tag, passed in via an
environment variable. If built outside of a github action context, the
version will be 0.0.0.

Updated to build off the on.push.tags event.
Only build for semver compatible tags.

DEVOPS-3586